### PR TITLE
pin-1385: Read model tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,8 @@ runStandalone := {
 }
 
 lazy val generated = project
+  .configs(IntegrationTest)
+  .settings(Defaults.itSettings: _*)
   .in(file("generated"))
   .settings(
     scalacOptions       := Seq(),
@@ -122,9 +124,15 @@ lazy val client = project
   )
 
 lazy val root = (project in file("."))
+  .configs(IntegrationTest)
+  .settings(Defaults.itSettings: _*)
   .settings(
     name                        := "interop-be-purpose-management",
     Test / parallelExecution    := false,
+    Test / fork                 := true,
+    Test / javaOptions += "-Dconfig.file=src/test/resources/application-test.conf",
+    IntegrationTest / fork      := true,
+    IntegrationTest / javaOptions += "-Dconfig.file=src/it/resources/application-it.conf",
     scalafmtOnCompile           := true,
     libraryDependencies         := Dependencies.Jars.`server`,
     dockerBuildOptions ++= Seq("--network=host"),
@@ -144,6 +152,3 @@ lazy val root = (project in file("."))
   .setupBuildInfo
 
 javaAgents += "io.kamon" % "kanela-agent" % "1.0.14"
-
-Test / fork := true
-Test / javaOptions += "-Dconfig.file=src/test/resources/application-test.conf"

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,6 @@ lazy val models = project
   .in(file("models"))
   .settings(
     name                := "interop-be-purpose-management-models",
-    scalacOptions       := Seq(),
     libraryDependencies := Dependencies.Jars.models,
     scalafmtOnCompile   := true,
     Docker / publish    := {},

--- a/models/src/main/scala/it/pagopa/interop/purposemanagement/model/purpose/PersistentRiskAnalysisForm.scala
+++ b/models/src/main/scala/it/pagopa/interop/purposemanagement/model/purpose/PersistentRiskAnalysisForm.scala
@@ -1,7 +1,5 @@
 package it.pagopa.interop.purposemanagement.model.purpose
 
-import it.pagopa.interop.commons.utils.service.UUIDSupplier
-import it.pagopa.interop.purposemanagement.model._
 import java.util.UUID
 
 object PersistentRiskAnalysisForm

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -113,7 +113,7 @@ object Dependencies {
       Seq(jackson.annotations % Compile, jackson.core % Compile, jackson.databind % Compile)
     lazy val `server`: Seq[ModuleID]  = Seq(
       // For making Java 12 happy
-      "javax.annotation"          % "javax.annotation-api" % "1.3.2" % "compile",
+      "javax.annotation"          % "javax.annotation-api"           % "1.3.2"                    % "compile",
       //
       akka.actorTyped             % Compile,
       akka.clusterBootstrap       % Compile,
@@ -142,17 +142,18 @@ object Dependencies {
       kamon.prometheus            % Compile,
       logback.classic             % Compile,
       mustache.mustache           % Compile,
-      pagopa.commonsUtils         % Compile,
+      pagopa.commonsUtils         % "compile,it",
       pagopa.commonsJWT           % Compile,
       pagopa.commonsQueue         % Compile,
-      pagopa.commonsCqrs          % Compile,
-      postgres.jdbc               % Compile,
+      pagopa.commonsCqrs          % "compile,it",
+      postgres.jdbc               % "compile,it",
       scalaprotobuf.core          % Compile,
       scalaprotobuf.core          % Protobuf,
-      scalatest.core              % Test,
-      scalamock.core              % Test,
-      akka.httpTestkit            % Test,
-      akka.testkit                % Test
+      scalatest.core              % "test,it",
+      scalamock.core              % "test,it",
+      akka.httpTestkit            % "test,it",
+      akka.testkit                % "test,it",
+      "com.dimafeng"             %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % IntegrationTest
     )
 
     val models: Seq[ModuleID] = Seq(spray.core, cats.core, pagopa.commonsUtils, pagopa.commonsQueue).map(_ % Compile)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,8 +19,9 @@ object Versions {
   lazy val scalatestVersion            = "3.2.12"
   lazy val slickProjectionVersion      = "1.2.2"
   lazy val sprayVersion                = "1.3.6"
+  lazy val testcontainersScalaVersion  = "0.40.9"
 }
 
 object PagopaVersions {
-  lazy val commonsVersion = "1.0.x-SNAPSHOT"
+  lazy val commonsVersion = "pin-1385-SNAPSHOT"
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -23,5 +23,5 @@ object Versions {
 }
 
 object PagopaVersions {
-  lazy val commonsVersion = "pin-1385-SNAPSHOT"
+  lazy val commonsVersion = "1.0.x-SNAPSHOT"
 }

--- a/src/it/resources/application-it.conf
+++ b/src/it/resources/application-it.conf
@@ -1,0 +1,64 @@
+include "persistence-jdbc"
+
+akka {
+
+  stdout-loglevel = "INFO"
+  loglevel = "INFO"
+  use-slf4j = on
+
+  actor.provider = cluster
+
+  remote.classic.netty.tcp.port = 0
+
+  remote.artery {
+    canonical.port = 0
+    canonical.hostname = 127.0.0.1
+  }
+
+  coordinated-shutdown {
+    terminate-actor-system = off
+    run-by-actor-system-terminate = off
+    run-by-jvm-shutdown-hook = off
+  }
+
+  cluster {
+    jmx.multi-mbeans-in-same-jvm = on
+    run-coordinated-shutdown-when-down = off
+    sharding {
+      number-of-shards = 5
+    }
+  }
+
+  typed {
+    stash-capacity = 200000
+  }
+}
+
+purpose-management {
+  url = "http://localhost:18088/purpose-management/"
+  port = 18088
+
+  idle-timeout = 60 seconds
+  number-of-events-before-snapshot = 1000
+
+  persistence-events-queue-url = "queue_url"
+
+  jwt {
+    audience = "aud"
+  }
+}
+
+interop-commons {
+  jwt {
+    public-keys {
+      urls = "https://interop.uat.selfcare.pagopa.it/.well-known/jwks.json"
+    }
+  }
+}
+
+futures-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  throughput = 1
+  thread-pool-executor.fixed-pool-size-min = 4
+}

--- a/src/it/resources/docker-compose-it.yaml
+++ b/src/it/resources/docker-compose-it.yaml
@@ -1,0 +1,19 @@
+version: '3.0'
+services:
+  postgres:
+    image: postgres:10.6
+    ports:
+      - '54329:5432'
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_DB: test
+      POSTGRES_PASSWORD: test
+    volumes:
+      - ./postgre_init.sql:/docker-entrypoint-initdb.d/postgre_init.sql
+  mongo:
+    image: mongo:4.0.28
+    ports:
+      - '27019:27017'
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: test
+      MONGO_INITDB_ROOT_PASSWORD: test

--- a/src/it/resources/logback-test.xml
+++ b/src/it/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="it.pagopa.interop.commons.logging.LoggerLayout"/>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="CONSOLE" />
+    </appender>
+
+    <root level="OFF">
+        <appender-ref ref="ASYNC"/>
+    </root>
+
+</configuration>

--- a/src/it/resources/persistence-jdbc.conf
+++ b/src/it/resources/persistence-jdbc.conf
@@ -1,0 +1,75 @@
+akka {
+  persistence {
+    journal {
+      plugin = "jdbc-journal"
+      auto-start-journals = ["jdbc-journal"]
+    }
+    snapshot-store {
+      plugin = "jdbc-snapshot-store"
+      auto-start-snapshot-stores = ["jdbc-snapshot-store"]
+    }
+  }
+  projection {
+    enabled = true
+  }
+}
+
+akka-persistence-jdbc {
+  shared-databases {
+    slick {
+      profile = "slick.jdbc.PostgresProfile$"
+      connectionPool = "HikariCP"
+      db {
+        host = "localhost"
+        url = "jdbc:postgresql://localhost:54329/test?reWriteBatchedInserts=true"
+        user = "test"
+        password = "test"
+        driver = "org.postgresql.Driver"
+        numThreads = 5
+        maxConnections = 5
+        minConnections = 1
+      }
+    }
+  }
+}
+
+jdbc-journal {
+  use-shared-db = "slick"
+  tables {
+    event_journal {
+        schemaName = "persistence"
+    }
+    event_tag {
+        schemaName = "persistence"
+    }
+  }
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  use-shared-db = "slick"
+  tables {
+    snapshot {
+        schemaName = "persistence"
+    }
+  }
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  use-shared-db = "slick"
+}
+
+akka.projection.slick {
+  offset-store {
+    schema = "persistence"
+  }
+}
+
+cqrs-projection {
+  db {
+    name = "integration_test"
+    connection-string = "mongodb://test:test@localhost:27019/?directConnection=true&serverSelectionTimeoutMS=2000"
+    collection-name = "test_collection"
+  }
+}

--- a/src/it/resources/postgre_init.sql
+++ b/src/it/resources/postgre_init.sql
@@ -1,0 +1,70 @@
+CREATE SCHEMA "persistence";
+
+CREATE TABLE IF NOT EXISTS "persistence".event_journal(
+  ordering BIGSERIAL,
+  persistence_id VARCHAR(255) NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE NOT NULL,
+
+  writer VARCHAR(255) NOT NULL,
+  write_timestamp BIGINT,
+  adapter_manifest VARCHAR(255),
+
+  event_ser_id INTEGER NOT NULL,
+  event_ser_manifest VARCHAR(255) NOT NULL,
+  event_payload BYTEA NOT NULL,
+
+  meta_ser_id INTEGER,
+  meta_ser_manifest VARCHAR(255),
+  meta_payload BYTEA,
+
+  PRIMARY KEY(persistence_id, sequence_number)
+);
+
+CREATE UNIQUE INDEX event_journal_ordering_idx ON "persistence".event_journal(ordering);
+
+CREATE TABLE IF NOT EXISTS "persistence".event_tag(
+    event_id BIGINT,
+    tag VARCHAR(256),
+    PRIMARY KEY(event_id, tag),
+    CONSTRAINT fk_event_journal
+      FOREIGN KEY(event_id)
+      REFERENCES "persistence".event_journal(ordering)
+      ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "persistence".snapshot (
+  persistence_id VARCHAR(255) NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  created BIGINT NOT NULL,
+
+  snapshot_ser_id INTEGER NOT NULL,
+  snapshot_ser_manifest VARCHAR(255) NOT NULL,
+  snapshot_payload BYTEA NOT NULL,
+
+  meta_ser_id INTEGER,
+  meta_ser_manifest VARCHAR(255),
+  meta_payload BYTEA,
+
+  PRIMARY KEY(persistence_id, sequence_number)
+);
+
+CREATE TABLE IF NOT EXISTS "persistence".akka_projection_offset_store (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  current_offset VARCHAR(255) NOT NULL,
+  manifest VARCHAR(4) NOT NULL,
+  mergeable BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);
+
+CREATE INDEX IF NOT EXISTS projection_name_index ON "persistence".akka_projection_offset_store (projection_name);
+
+CREATE TABLE IF NOT EXISTS "persistence".akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/src/it/scala/it/pagopa/interop/purposemanagement/ItCqrsSpec.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/ItCqrsSpec.scala
@@ -1,0 +1,92 @@
+package it.pagopa.interop.purposemanagement
+
+import com.dimafeng.testcontainers.DockerComposeContainer
+import com.dimafeng.testcontainers.DockerComposeContainer.ComposeFile
+import com.dimafeng.testcontainers.scalatest.TestContainersForAll
+import it.pagopa.interop.commons.cqrs.model.{CqrsMetadata, MongoDbConfig}
+import it.pagopa.interop.purposemanagement.common.system.ApplicationConfiguration
+import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
+import org.mongodb.scala.connection.NettyStreamFactoryFactory
+import org.mongodb.scala.model.Filters
+import org.mongodb.scala.{ConnectionString, Document, MongoClient, MongoClientSettings}
+import org.scalatest.wordspec.AnyWordSpecLike
+import spray.json._
+
+import java.io.File
+import scala.concurrent.{ExecutionContext, Future}
+
+// Testing only the projection is not possible (https://github.com/akka/akka-projection/issues/454)
+
+trait ItCqrsSpec extends AnyWordSpecLike with TestContainersForAll {
+
+  private var internalMongodbClient: Option[MongoClient] = None
+  private val mongoDbConfig: MongoDbConfig               = ApplicationConfiguration.mongoDb
+
+  def startServer(): Unit
+  def shutdownServer(): Unit
+
+  override type Containers = DockerComposeContainer
+
+  override def startContainers(): Containers =
+    // Not able to use prepared PostgreSQL and MongoDB containers because ports are randomly generated, but
+    //   akka testkit needs to load configuration at startup, so there is no time to override db configs
+    DockerComposeContainer
+      .Def(composeFiles = ComposeFile(Left(new File("src/it/resources/docker-compose-it.yaml"))))
+      .start()
+
+  override def afterContainersStart(containers: Containers): Unit = {
+    super.afterContainersStart(containers)
+
+    internalMongodbClient = Some(
+      MongoClient(
+        MongoClientSettings
+          .builder()
+          .applyConnectionString(new ConnectionString(mongoDbConfig.connectionString))
+          .codecRegistry(DEFAULT_CODEC_REGISTRY)
+          .streamFactoryFactory(NettyStreamFactoryFactory())
+          .build()
+      )
+    )
+
+    startServer()
+  }
+
+  def mongodbClient: MongoClient = internalMongodbClient match {
+    case Some(client) => client
+    case None         => throw new Exception("MongoDB client not yet initialized")
+  }
+
+  def findOne[T: JsonReader](id: String)(implicit ec: ExecutionContext): Future[T] = find[T](id).map(_.head)
+
+  def find[T: JsonReader](id: String)(implicit ec: ExecutionContext): Future[Seq[T]] = for {
+    // Wait a reasonable amount of time to allow the event to be processed by the projection
+    _       <- Future.successful(Thread.sleep(2500))
+    results <- mongodbClient
+      .getDatabase(mongoDbConfig.dbName)
+      .getCollection(mongoDbConfig.collectionName)
+      .find(Filters.eq("data.id", id))
+      .toFuture()
+  } yield results.map(extractData[T])
+
+  private def extractData[T: JsonReader](document: Document): T = {
+    val fields = document.toJson().parseJson.asJsObject.getFields("data", "metadata")
+    fields match {
+      case data :: metadata :: Nil =>
+        val cqrsMetadata = metadata.convertTo[CqrsMetadata]
+
+        assert(cqrsMetadata.sourceEvent.persistenceId.nonEmpty)
+        assert(cqrsMetadata.sourceEvent.sequenceNr >= 0)
+        assert(cqrsMetadata.sourceEvent.timestamp > 0)
+
+        data.convertTo[T]
+      case _                       => fail(s"Unexpected number of fields ${fields.size}. Content: $fields")
+    }
+  }
+
+  override def beforeContainersStop(containers: Containers): Unit = {
+    shutdownServer()
+    internalMongodbClient.get.close()
+    super.afterContainersStart(containers)
+  }
+
+}

--- a/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecConfiguration.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecConfiguration.scala
@@ -1,0 +1,30 @@
+package it.pagopa.interop.purposemanagement
+
+import akka.http.scaladsl.server.Directives.Authenticator
+import akka.http.scaladsl.server.directives.Credentials
+import akka.http.scaladsl.server.directives.Credentials.{Missing, Provided}
+import com.typesafe.config.{Config, ConfigFactory}
+import it.pagopa.interop.commons.utils.{BEARER, USER_ROLES}
+
+/** Selfless trait containing base test configuration for Akka Cluster Setup
+  */
+trait ItSpecConfiguration {
+
+  val config: Config = ConfigFactory.load()
+
+  def serviceURL: String =
+    s"${config.getString("purpose-management.url")}${buildinfo.BuildInfo.interfaceVersion}"
+
+}
+
+object ItSpecConfiguration extends ItSpecConfiguration
+
+//mocks admin user role rights for every call
+object AdminMockAuthenticator extends Authenticator[Seq[(String, String)]] {
+  override def apply(credentials: Credentials): Option[Seq[(String, String)]] = {
+    credentials match {
+      case Provided(identifier) => Some(Seq(BEARER -> identifier, USER_ROLES -> "admin"))
+      case Missing              => None
+    }
+  }
+}

--- a/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecData.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecData.scala
@@ -1,0 +1,45 @@
+package it.pagopa.interop.purposemanagement
+
+import it.pagopa.interop.purposemanagement.model.RiskAnalysisForm
+import it.pagopa.interop.purposemanagement.model.purpose._
+
+import java.time.{OffsetDateTime, ZoneOffset}
+import java.util.UUID
+
+object ItSpecData {
+  final val timestamp: OffsetDateTime = OffsetDateTime.of(2022, 12, 31, 11, 22, 33, 0, ZoneOffset.UTC)
+
+  def persistentDocument: PersistentPurposeVersionDocument =
+    PersistentPurposeVersionDocument(id = UUID.randomUUID(), contentType = "json", path = "path", createdAt = timestamp)
+
+  def riskAnalysisForm: RiskAnalysisForm =
+    RiskAnalysisForm(id = UUID.randomUUID(), version = UUID.randomUUID().toString, Seq.empty, Seq.empty)
+
+  def persistentPurposeVersion: PersistentPurposeVersion = PersistentPurposeVersion(
+    id = UUID.randomUUID(),
+    state = Draft,
+    expectedApprovalDate = Some(timestamp),
+    riskAnalysis = Some(persistentDocument),
+    dailyCalls = 1111,
+    createdAt = timestamp,
+    updatedAt = Some(timestamp),
+    firstActivationAt = Some(timestamp)
+  )
+
+  def persistentRiskAnalysisForm: PersistentRiskAnalysisForm =
+    PersistentRiskAnalysisForm(id = riskAnalysisForm.id, version = riskAnalysisForm.version, Seq.empty, Seq.empty)
+
+  def persistentPurpose: PersistentPurpose = PersistentPurpose(
+    id = UUID.randomUUID(),
+    eserviceId = UUID.randomUUID(),
+    consumerId = UUID.randomUUID(),
+    versions = Seq(persistentPurposeVersion),
+    suspendedByConsumer = Some(false),
+    suspendedByProducer = Some(true),
+    title = "A Title",
+    description = "A description",
+    riskAnalysisForm = Some(persistentRiskAnalysisForm),
+    createdAt = timestamp,
+    updatedAt = Some(timestamp)
+  )
+}

--- a/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecHelper.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecHelper.scala
@@ -17,7 +17,7 @@ import it.pagopa.interop.commons.utils.service.{OffsetDateTimeSupplier, UUIDSupp
 import it.pagopa.interop.purposemanagement.api._
 import it.pagopa.interop.purposemanagement.api.impl._
 import it.pagopa.interop.purposemanagement.common.system.ApplicationConfiguration
-import it.pagopa.interop.purposemanagement.model.decoupling.PurposeUpdate
+import it.pagopa.interop.purposemanagement.model.decoupling.{DraftPurposeVersionUpdate, PurposeUpdate}
 import it.pagopa.interop.purposemanagement.model.persistence._
 import it.pagopa.interop.purposemanagement.model.purpose._
 import it.pagopa.interop.purposemanagement.model.{PurposeVersionDocument, StateChangeDetails}
@@ -116,11 +116,20 @@ trait ItSpecHelper
   def createPurpose(persistentPurpose: PersistentPurpose): PersistentPurpose =
     commander(persistentPurpose.id).ask(ref => CreatePurpose(persistentPurpose, ref)).futureValue.getValue
 
+  def deletePurpose(purposeId: UUID): Unit =
+    commander(purposeId).ask(ref => DeletePurpose(purposeId.toString, ref)).futureValue.getValue
+
   def updatePurpose(purposeId: UUID, update: PurposeUpdate): PersistentPurpose =
     commander(purposeId).ask(ref => UpdatePurpose(purposeId.toString, update, ref)).futureValue.getValue
 
   def createVersion(purposeId: UUID, version: PersistentPurposeVersion): PersistentPurposeVersion =
     commander(purposeId).ask(ref => CreatePurposeVersion(purposeId.toString, version, ref)).futureValue.getValue
+
+  def deleteVersion(purposeId: UUID, versionId: UUID): Unit =
+    commander(purposeId)
+      .ask(ref => DeletePurposeVersion(purposeId.toString, versionId.toString, ref))
+      .futureValue
+      .getValue
 
   def activateVersion(
     purposeId: UUID,
@@ -162,5 +171,15 @@ trait ItSpecHelper
       .futureValue
       .getValue
   }
+
+  def updateDraftVersion(
+    purposeId: UUID,
+    versionId: UUID,
+    update: DraftPurposeVersionUpdate
+  ): PersistentPurposeVersion =
+    commander(purposeId)
+      .ask(ref => UpdateDraftPurposeVersion(purposeId.toString, versionId.toString, update, ref))
+      .futureValue
+      .getValue
 
 }

--- a/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecHelper.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecHelper.scala
@@ -1,0 +1,299 @@
+package it.pagopa.interop.purposemanagement
+
+import akka.actor
+import akka.actor.testkit.typed.scaladsl.{ActorTestKit, ScalaTestWithActorTestKit}
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.cluster.sharding.typed.ShardingEnvelope
+import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, Entity, EntityRef}
+import akka.cluster.typed.{Cluster, Join}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.server.directives.{AuthenticationDirective, SecurityDirectives}
+import it.pagopa.interop.commons.utils.AkkaUtils.getShard
+import it.pagopa.interop.commons.utils.service.{OffsetDateTimeSupplier, UUIDSupplier}
+import it.pagopa.interop.purposemanagement.api._
+import it.pagopa.interop.purposemanagement.api.impl._
+import it.pagopa.interop.purposemanagement.common.system.ApplicationConfiguration
+import it.pagopa.interop.purposemanagement.model.decoupling.PurposeUpdate
+import it.pagopa.interop.purposemanagement.model.persistence._
+import it.pagopa.interop.purposemanagement.model.purpose._
+import it.pagopa.interop.purposemanagement.server.Controller
+import it.pagopa.interop.purposemanagement.server.impl.Dependencies
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.Assertion
+import spray.json._
+
+import java.net.InetAddress
+import java.util.UUID
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+
+trait ItSpecHelper
+    extends ItSpecConfiguration
+    with ItCqrsSpec
+    with MockFactory
+    with SprayJsonSupport
+    with DefaultJsonProtocol
+    with Dependencies {
+  self: ScalaTestWithActorTestKit =>
+
+  val bearerToken: String                   = "token"
+  final val requestHeaders: Seq[HttpHeader] =
+    Seq(
+      headers.Authorization(OAuth2BearerToken("token")),
+      headers.RawHeader("X-Correlation-Id", "test-id"),
+      headers.`X-Forwarded-For`(RemoteAddress(InetAddress.getByName("127.0.0.1")))
+    )
+
+  val mockUUIDSupplier: UUIDSupplier               = mock[UUIDSupplier]
+  val mockDateTimeSupplier: OffsetDateTimeSupplier = mock[OffsetDateTimeSupplier]
+
+  val apiMarshaller: PurposeApiMarshaller = PurposeApiMarshallerImpl
+
+  var controller: Option[Controller]                 = None
+  var bindServer: Option[Future[Http.ServerBinding]] = None
+
+  val wrappingDirective: AuthenticationDirective[Seq[(String, String)]] =
+    SecurityDirectives.authenticateOAuth2("SecurityRealm", AdminMockAuthenticator)
+
+  val sharding: ClusterSharding                 = ClusterSharding(system)
+  def commander(id: UUID): EntityRef[Command]   = commander(id.toString)
+  def commander(id: String): EntityRef[Command] =
+    sharding.entityRefFor(
+      PurposePersistentBehavior.TypeKey,
+      getShard(id, ApplicationConfiguration.numberOfProjectionTags)
+    )
+
+  val httpSystem: ActorSystem[Any]                        =
+    ActorSystem(Behaviors.ignore[Any], name = system.name, config = system.settings.config)
+  implicit val executionContext: ExecutionContextExecutor = httpSystem.executionContext
+  val classicSystem: actor.ActorSystem                    = httpSystem.classicSystem
+
+  override def startServer(): Unit = {
+    val persistentEntity: Entity[Command, ShardingEnvelope[Command]] =
+      Entity(PurposePersistentBehavior.TypeKey)(behaviorFactory(mockDateTimeSupplier))
+
+    Cluster(system).manager ! Join(Cluster(system).selfMember.address)
+    sharding.init(persistentEntity)
+
+    val attributeApi =
+      new PurposeApi(
+        PurposeApiServiceImpl(system, sharding, persistentEntity, mockUUIDSupplier, mockDateTimeSupplier),
+        apiMarshaller,
+        wrappingDirective
+      )
+
+    if (ApplicationConfiguration.projectionsEnabled) initCqrsProjection()
+
+    controller = Some(new Controller(attributeApi)(classicSystem))
+
+    controller foreach { controller =>
+      bindServer = Some(
+        Http()(classicSystem)
+          .newServerAt("0.0.0.0", 18088)
+          .bind(controller.routes)
+      )
+
+      Await.result(bindServer.get, 100.seconds)
+    }
+  }
+
+  override def shutdownServer(): Unit = {
+    bindServer.foreach(_.foreach(_.unbind()))
+    ActorTestKit.shutdown(httpSystem, 5.seconds)
+  }
+
+  def comparePurposes(item1: PersistentPurpose, item2: PersistentPurpose): Assertion =
+    sortPurposeArrayFields(item1) shouldBe sortPurposeArrayFields(item2)
+
+  def sortPurposeArrayFields(purpose: PersistentPurpose): PersistentPurpose =
+    purpose.copy(versions = purpose.versions.sortBy(_.id))
+
+  def createPurpose(persistentPurpose: PersistentPurpose): PersistentPurpose =
+    commander(persistentPurpose.id).ask(ref => CreatePurpose(persistentPurpose, ref)).futureValue.getValue
+
+  def updatePurpose(purposeId: UUID, update: PurposeUpdate): PersistentPurpose =
+    commander(purposeId).ask(ref => UpdatePurpose(purposeId.toString, update, ref)).futureValue.getValue
+
+  def createVersion(purposeId: UUID, version: PersistentPurposeVersion): PersistentPurposeVersion =
+    commander(purposeId).ask(ref => CreatePurposeVersion(purposeId.toString, version, ref)).futureValue.getValue
+
+  //  def createPurpose(purposeId: UUID): Future[Purpose] =
+//    for {
+//      seed <- Future.successful(
+//        PurposeSeed(
+//          eserviceId = UUID.randomUUID(),
+//          consumerId = UUID.randomUUID(),
+//          title = "A title",
+//          description = "A description",
+//          riskAnalysisForm = Some(riskAnalysisFormSeed)
+//        )
+//      )
+//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
+//      _ = (() => mockUUIDSupplier.get).expects().returning(purposeId).once()
+//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
+//      _ = (() => mockUUIDSupplier.get).expects().returning(riskAnalysisForm.id).once()
+//      purpose <- Unmarshal(makeRequest(data, "purposes", HttpMethods.POST)).to[Purpose]
+//    } yield purpose
+//
+//  def createPurposeVersion(purposeId: UUID, versionId: UUID, seed: PurposeVersionSeed)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[PurposeVersion] =
+//    for {
+//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
+//      _ = (() => mockUUIDSupplier.get).expects().returning(versionId).once()
+//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
+//      purpose <- Unmarshal(makeRequest(data, s"purposes/$purposeId/versions", HttpMethods.POST)).to[PurposeVersion]
+//    } yield purpose
+//
+//  def updatePurpose(purposeId: UUID, seed: PurposeUpdateContent)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[Purpose] =
+//    for {
+//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
+//      _ = (() => mockUUIDSupplier.get).expects().returning(UUID.randomUUID()).once()
+//      purpose <- Unmarshal(makeRequest(data, s"purposes/$purposeId", HttpMethods.POST))
+//        .to[Purpose]
+//    } yield purpose
+//
+//  def updateDraftPurposeVersion(purposeId: UUID, versionId: UUID, seed: DraftPurposeVersionUpdateContent)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[PurposeVersion] =
+//    for {
+//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
+//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
+//      purpose <- Unmarshal(makeRequest(data, s"purposes/$purposeId/versions/$versionId/update/draft", HttpMethods.POST))
+//        .to[PurposeVersion]
+//    } yield purpose
+//
+//  def updateWaitingForApprovalPurposeVersion(
+//    purposeId: UUID,
+//    versionId: UUID,
+//    seed: WaitingForApprovalPurposeVersionUpdateContent
+//  )(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[PurposeVersion] =
+//    for {
+//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
+//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
+//      purpose <- Unmarshal(
+//        makeRequest(data, s"purposes/$purposeId/versions/$versionId/update/waitingForApproval", HttpMethods.POST)
+//      )
+//        .to[PurposeVersion]
+//    } yield purpose
+//
+//  def deletePurpose(
+//    purposeId: UUID
+//  )(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[Option[String]] =
+//    Unmarshal(makeRequest(emptyData, s"purposes/$purposeId", HttpMethods.DELETE)).to[Option[String]]
+//
+//  def deletePurposeVersion(purposeId: UUID, versionId: UUID)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[Option[String]] =
+//    Unmarshal(makeRequest(emptyData, s"purposes/$purposeId/versions/$versionId", HttpMethods.DELETE)).to[Option[String]]
+//
+//  def makeFailingRequest[T](url: String, verb: HttpMethod, data: T)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem,
+//    marshaller: Marshaller[T, MessageEntity]
+//  ): Future[Problem] =
+//    for {
+//      body    <- Marshal(data).to[MessageEntity].map(_.dataBytes)
+//      purpose <- Unmarshal(makeRequest(body, url, verb)).to[Problem]
+//    } yield purpose
+//
+//  def makeFailingRequest(url: String, verb: HttpMethod)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[Problem] = makeFailingRequest(url, verb, "")
+//
+//  def getPurpose(id: UUID)(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[Purpose] = {
+//    val response = makeRequest(emptyData, s"purposes/${id.toString}", HttpMethods.GET)
+//    Unmarshal(response).to[Purpose]
+//  }
+//
+//  def getPurposes(
+//    eServiceId: Option[UUID] = None,
+//    consumerId: Option[UUID] = None,
+//    states: Seq[PurposeVersionState] = Seq.empty
+//  )(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[Purposes] = {
+//    val eServiceParam = eServiceId.fold("")(id => s"eserviceId=${id.toString}")
+//    val consumerParam = consumerId.fold("")(id => s"consumerId=${id.toString}")
+//    val stateParam    = states.mkString("states=", ",", "")
+//
+//    val params   = Seq(eServiceParam, consumerParam, stateParam).mkString("?", "&", "")
+//    val response = makeRequest(emptyData, s"purposes$params", HttpMethods.GET)
+//    Unmarshal(response).to[Purposes]
+//  }
+//
+//  def activateVersion(
+//    purposeId: UUID,
+//    versionId: UUID,
+//    changedBy: ChangedBy,
+//    riskAnalysis: Option[PurposeVersionDocument],
+//    timestamp: OffsetDateTime = timestamp
+//  )(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[PurposeVersion] = {
+//    for {
+//      data <- Marshal(
+//        ActivatePurposeVersionPayload(
+//          riskAnalysis = riskAnalysis,
+//          stateChangeDetails = StateChangeDetails(changedBy = changedBy)
+//        )
+//      )
+//        .to[MessageEntity]
+//        .map(_.dataBytes)
+//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
+//      result <- Unmarshal(makeRequest(data, s"purposes/$purposeId/versions/$versionId/activate", HttpMethods.POST))
+//        .to[PurposeVersion]
+//    } yield result
+//  }
+//
+//  def suspendVersion(purposeId: UUID, versionId: UUID, changedBy: ChangedBy)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[PurposeVersion] =
+//    changeVersionState(purposeId, versionId, changedBy, "suspend")
+//
+//  def waitForApprovalVersion(purposeId: UUID, versionId: UUID, changedBy: ChangedBy)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[PurposeVersion] =
+//    changeVersionState(purposeId, versionId, changedBy, "waitForApproval")
+//
+//  def archiveVersion(purposeId: UUID, versionId: UUID, changedBy: ChangedBy)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[PurposeVersion] =
+//    changeVersionState(purposeId, versionId, changedBy, "archive")
+//
+//  def changeVersionState(purposeId: UUID, versionId: UUID, changedBy: ChangedBy, statePath: String)(implicit
+//    ec: ExecutionContext,
+//    actorSystem: actor.ActorSystem
+//  ): Future[PurposeVersion] = for {
+//    data <- Marshal(StateChangeDetails(changedBy = changedBy))
+//      .to[MessageEntity]
+//      .map(_.dataBytes)
+//    _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
+//    result <- Unmarshal(makeRequest(data, s"purposes/$purposeId/versions/$versionId/$statePath", HttpMethods.POST))
+//      .to[PurposeVersion]
+//  } yield result
+//
+//  def makeRequest(data: Source[ByteString, Any], path: String, verb: HttpMethod): HttpResponse = {
+//    Await.result(
+//      Http().singleRequest(
+//        HttpRequest(
+//          uri = s"$url/$path",
+//          method = verb,
+//          entity = HttpEntity(ContentTypes.`application/json`, data),
+//          headers = requestHeaders
+//        )
+//      ),
+//      Duration.Inf
+//    )
+//  }
+}

--- a/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecHelper.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecHelper.scala
@@ -20,6 +20,7 @@ import it.pagopa.interop.purposemanagement.common.system.ApplicationConfiguratio
 import it.pagopa.interop.purposemanagement.model.decoupling.PurposeUpdate
 import it.pagopa.interop.purposemanagement.model.persistence._
 import it.pagopa.interop.purposemanagement.model.purpose._
+import it.pagopa.interop.purposemanagement.model.{PurposeVersionDocument, StateChangeDetails}
 import it.pagopa.interop.purposemanagement.server.Controller
 import it.pagopa.interop.purposemanagement.server.impl.Dependencies
 import org.scalamock.scalatest.MockFactory
@@ -121,179 +122,25 @@ trait ItSpecHelper
   def createVersion(purposeId: UUID, version: PersistentPurposeVersion): PersistentPurposeVersion =
     commander(purposeId).ask(ref => CreatePurposeVersion(purposeId.toString, version, ref)).futureValue.getValue
 
-  //  def createPurpose(purposeId: UUID): Future[Purpose] =
-//    for {
-//      seed <- Future.successful(
-//        PurposeSeed(
-//          eserviceId = UUID.randomUUID(),
-//          consumerId = UUID.randomUUID(),
-//          title = "A title",
-//          description = "A description",
-//          riskAnalysisForm = Some(riskAnalysisFormSeed)
-//        )
-//      )
-//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
-//      _ = (() => mockUUIDSupplier.get).expects().returning(purposeId).once()
-//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
-//      _ = (() => mockUUIDSupplier.get).expects().returning(riskAnalysisForm.id).once()
-//      purpose <- Unmarshal(makeRequest(data, "purposes", HttpMethods.POST)).to[Purpose]
-//    } yield purpose
-//
-//  def createPurposeVersion(purposeId: UUID, versionId: UUID, seed: PurposeVersionSeed)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[PurposeVersion] =
-//    for {
-//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
-//      _ = (() => mockUUIDSupplier.get).expects().returning(versionId).once()
-//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
-//      purpose <- Unmarshal(makeRequest(data, s"purposes/$purposeId/versions", HttpMethods.POST)).to[PurposeVersion]
-//    } yield purpose
-//
-//  def updatePurpose(purposeId: UUID, seed: PurposeUpdateContent)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[Purpose] =
-//    for {
-//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
-//      _ = (() => mockUUIDSupplier.get).expects().returning(UUID.randomUUID()).once()
-//      purpose <- Unmarshal(makeRequest(data, s"purposes/$purposeId", HttpMethods.POST))
-//        .to[Purpose]
-//    } yield purpose
-//
-//  def updateDraftPurposeVersion(purposeId: UUID, versionId: UUID, seed: DraftPurposeVersionUpdateContent)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[PurposeVersion] =
-//    for {
-//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
-//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
-//      purpose <- Unmarshal(makeRequest(data, s"purposes/$purposeId/versions/$versionId/update/draft", HttpMethods.POST))
-//        .to[PurposeVersion]
-//    } yield purpose
-//
-//  def updateWaitingForApprovalPurposeVersion(
-//    purposeId: UUID,
-//    versionId: UUID,
-//    seed: WaitingForApprovalPurposeVersionUpdateContent
-//  )(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[PurposeVersion] =
-//    for {
-//      data <- Marshal(seed).to[MessageEntity].map(_.dataBytes)
-//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
-//      purpose <- Unmarshal(
-//        makeRequest(data, s"purposes/$purposeId/versions/$versionId/update/waitingForApproval", HttpMethods.POST)
-//      )
-//        .to[PurposeVersion]
-//    } yield purpose
-//
-//  def deletePurpose(
-//    purposeId: UUID
-//  )(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[Option[String]] =
-//    Unmarshal(makeRequest(emptyData, s"purposes/$purposeId", HttpMethods.DELETE)).to[Option[String]]
-//
-//  def deletePurposeVersion(purposeId: UUID, versionId: UUID)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[Option[String]] =
-//    Unmarshal(makeRequest(emptyData, s"purposes/$purposeId/versions/$versionId", HttpMethods.DELETE)).to[Option[String]]
-//
-//  def makeFailingRequest[T](url: String, verb: HttpMethod, data: T)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem,
-//    marshaller: Marshaller[T, MessageEntity]
-//  ): Future[Problem] =
-//    for {
-//      body    <- Marshal(data).to[MessageEntity].map(_.dataBytes)
-//      purpose <- Unmarshal(makeRequest(body, url, verb)).to[Problem]
-//    } yield purpose
-//
-//  def makeFailingRequest(url: String, verb: HttpMethod)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[Problem] = makeFailingRequest(url, verb, "")
-//
-//  def getPurpose(id: UUID)(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[Purpose] = {
-//    val response = makeRequest(emptyData, s"purposes/${id.toString}", HttpMethods.GET)
-//    Unmarshal(response).to[Purpose]
-//  }
-//
-//  def getPurposes(
-//    eServiceId: Option[UUID] = None,
-//    consumerId: Option[UUID] = None,
-//    states: Seq[PurposeVersionState] = Seq.empty
-//  )(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[Purposes] = {
-//    val eServiceParam = eServiceId.fold("")(id => s"eserviceId=${id.toString}")
-//    val consumerParam = consumerId.fold("")(id => s"consumerId=${id.toString}")
-//    val stateParam    = states.mkString("states=", ",", "")
-//
-//    val params   = Seq(eServiceParam, consumerParam, stateParam).mkString("?", "&", "")
-//    val response = makeRequest(emptyData, s"purposes$params", HttpMethods.GET)
-//    Unmarshal(response).to[Purposes]
-//  }
-//
-//  def activateVersion(
-//    purposeId: UUID,
-//    versionId: UUID,
-//    changedBy: ChangedBy,
-//    riskAnalysis: Option[PurposeVersionDocument],
-//    timestamp: OffsetDateTime = timestamp
-//  )(implicit ec: ExecutionContext, actorSystem: actor.ActorSystem): Future[PurposeVersion] = {
-//    for {
-//      data <- Marshal(
-//        ActivatePurposeVersionPayload(
-//          riskAnalysis = riskAnalysis,
-//          stateChangeDetails = StateChangeDetails(changedBy = changedBy)
-//        )
-//      )
-//        .to[MessageEntity]
-//        .map(_.dataBytes)
-//      _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
-//      result <- Unmarshal(makeRequest(data, s"purposes/$purposeId/versions/$versionId/activate", HttpMethods.POST))
-//        .to[PurposeVersion]
-//    } yield result
-//  }
-//
-//  def suspendVersion(purposeId: UUID, versionId: UUID, changedBy: ChangedBy)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[PurposeVersion] =
-//    changeVersionState(purposeId, versionId, changedBy, "suspend")
-//
-//  def waitForApprovalVersion(purposeId: UUID, versionId: UUID, changedBy: ChangedBy)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[PurposeVersion] =
-//    changeVersionState(purposeId, versionId, changedBy, "waitForApproval")
-//
-//  def archiveVersion(purposeId: UUID, versionId: UUID, changedBy: ChangedBy)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[PurposeVersion] =
-//    changeVersionState(purposeId, versionId, changedBy, "archive")
-//
-//  def changeVersionState(purposeId: UUID, versionId: UUID, changedBy: ChangedBy, statePath: String)(implicit
-//    ec: ExecutionContext,
-//    actorSystem: actor.ActorSystem
-//  ): Future[PurposeVersion] = for {
-//    data <- Marshal(StateChangeDetails(changedBy = changedBy))
-//      .to[MessageEntity]
-//      .map(_.dataBytes)
-//    _ = (() => mockDateTimeSupplier.get).expects().returning(timestamp).once()
-//    result <- Unmarshal(makeRequest(data, s"purposes/$purposeId/versions/$versionId/$statePath", HttpMethods.POST))
-//      .to[PurposeVersion]
-//  } yield result
-//
-//  def makeRequest(data: Source[ByteString, Any], path: String, verb: HttpMethod): HttpResponse = {
-//    Await.result(
-//      Http().singleRequest(
-//        HttpRequest(
-//          uri = s"$url/$path",
-//          method = verb,
-//          entity = HttpEntity(ContentTypes.`application/json`, data),
-//          headers = requestHeaders
-//        )
-//      ),
-//      Duration.Inf
-//    )
-//  }
+  def activateVersion(
+    purposeId: UUID,
+    versionId: UUID,
+    riskAnalysis: Option[PurposeVersionDocument],
+    stateChangeDetails: StateChangeDetails
+  ): PersistentPurpose = {
+    (() => mockDateTimeSupplier.get).expects().returning(ItSpecData.timestamp).once()
+    commander(purposeId)
+      .ask(ref => ActivatePurposeVersion(purposeId.toString, versionId.toString, riskAnalysis, stateChangeDetails, ref))
+      .futureValue
+      .getValue
+  }
+
+  def suspendVersion(purposeId: UUID, versionId: UUID, stateChangeDetails: StateChangeDetails): PersistentPurpose = {
+    (() => mockDateTimeSupplier.get).expects().returning(ItSpecData.timestamp).once()
+    commander(purposeId)
+      .ask(ref => SuspendPurposeVersion(purposeId.toString, versionId.toString, stateChangeDetails, ref))
+      .futureValue
+      .getValue
+  }
+
 }

--- a/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecHelper.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/ItSpecHelper.scala
@@ -143,4 +143,24 @@ trait ItSpecHelper
       .getValue
   }
 
+  def waitForApprovalVersion(
+    purposeId: UUID,
+    versionId: UUID,
+    stateChangeDetails: StateChangeDetails
+  ): PersistentPurpose = {
+    (() => mockDateTimeSupplier.get).expects().returning(ItSpecData.timestamp).once()
+    commander(purposeId)
+      .ask(ref => WaitForApprovalPurposeVersion(purposeId.toString, versionId.toString, stateChangeDetails, ref))
+      .futureValue
+      .getValue
+  }
+
+  def archiveVersion(purposeId: UUID, versionId: UUID, stateChangeDetails: StateChangeDetails): PersistentPurpose = {
+    (() => mockDateTimeSupplier.get).expects().returning(ItSpecData.timestamp).once()
+    commander(purposeId)
+      .ask(ref => ArchivePurposeVersion(purposeId.toString, versionId.toString, stateChangeDetails, ref))
+      .futureValue
+      .getValue
+  }
+
 }

--- a/src/it/scala/it/pagopa/interop/purposemanagement/projection/cqrs/CqrsProjectionSpec.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/projection/cqrs/CqrsProjectionSpec.scala
@@ -1,0 +1,42 @@
+package it.pagopa.interop.purposemanagement.projection.cqrs
+
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import it.pagopa.interop.purposemanagement.ItSpecData._
+import it.pagopa.interop.purposemanagement.model.decoupling.PurposeUpdate
+import it.pagopa.interop.purposemanagement.model.persistence.JsonFormats._
+import it.pagopa.interop.purposemanagement.model.purpose.{Archived, PersistentPurpose}
+import it.pagopa.interop.purposemanagement.{ItSpecConfiguration, ItSpecHelper}
+
+class CqrsProjectionSpec extends ScalaTestWithActorTestKit(ItSpecConfiguration.config) with ItSpecHelper {
+
+  "Projection" should {
+    "succeed for event PurposeCreated" in {
+      val expected  = createPurpose(persistentPurpose)
+      val persisted = findOne[PersistentPurpose](expected.id.toString).futureValue
+
+      comparePurposes(expected, persisted)
+    }
+
+    "succeed for event PurposeUpdated" in {
+      val purpose = createPurpose(persistentPurpose)
+      val update = PurposeUpdate(title = "New title", description = "new Description", Some(persistentRiskAnalysisForm))
+      val expected  = updatePurpose(purpose.id, update)
+      val persisted = findOne[PersistentPurpose](expected.id.toString).futureValue
+
+      comparePurposes(expected, persisted)
+    }
+
+    "succeed for event PurposeVersionCreated" in {
+      val purpose    =
+        createPurpose(persistentPurpose.copy(versions = Seq(persistentPurposeVersion.copy(state = Archived))))
+      val newVersion = createVersion(purpose.id, persistentPurposeVersion)
+      val expected   = purpose.copy(versions = purpose.versions :+ newVersion)
+
+      val persisted = findOne[PersistentPurpose](expected.id.toString).futureValue
+
+      comparePurposes(expected, persisted)
+    }
+
+  }
+
+}

--- a/src/it/scala/it/pagopa/interop/purposemanagement/projection/cqrs/CqrsProjectionSpec.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/projection/cqrs/CqrsProjectionSpec.scala
@@ -3,8 +3,10 @@ package it.pagopa.interop.purposemanagement.projection.cqrs
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import it.pagopa.interop.purposemanagement.ItSpecData._
 import it.pagopa.interop.purposemanagement.model.decoupling.PurposeUpdate
+import it.pagopa.interop.purposemanagement.model.persistence.Adapters._
 import it.pagopa.interop.purposemanagement.model.persistence.JsonFormats._
 import it.pagopa.interop.purposemanagement.model.purpose.{Archived, PersistentPurpose}
+import it.pagopa.interop.purposemanagement.model.{ChangedBy, StateChangeDetails}
 import it.pagopa.interop.purposemanagement.{ItSpecConfiguration, ItSpecHelper}
 
 class CqrsProjectionSpec extends ScalaTestWithActorTestKit(ItSpecConfiguration.config) with ItSpecHelper {
@@ -31,6 +33,33 @@ class CqrsProjectionSpec extends ScalaTestWithActorTestKit(ItSpecConfiguration.c
         createPurpose(persistentPurpose.copy(versions = Seq(persistentPurposeVersion.copy(state = Archived))))
       val newVersion = createVersion(purpose.id, persistentPurposeVersion)
       val expected   = purpose.copy(versions = purpose.versions :+ newVersion)
+
+      val persisted = findOne[PersistentPurpose](expected.id.toString).futureValue
+
+      comparePurposes(expected, persisted)
+    }
+
+    "succeed for event PurposeVersionActivated" in {
+      val stateChangeDetails = StateChangeDetails(changedBy = ChangedBy.PRODUCER)
+      val purpose            =
+        createPurpose(persistentPurpose.copy(versions = Seq(persistentPurposeVersion.copy(state = Archived))))
+      val version            = createVersion(purpose.id, persistentPurposeVersion)
+
+      val expected = activateVersion(purpose.id, version.id, Some(persistentDocument.toAPI), stateChangeDetails)
+
+      val persisted = findOne[PersistentPurpose](expected.id.toString).futureValue
+
+      comparePurposes(expected, persisted)
+    }
+
+    "succeed for event PurposeVersionSuspended" in {
+      val stateChangeDetails = StateChangeDetails(changedBy = ChangedBy.PRODUCER)
+      val purpose            =
+        createPurpose(persistentPurpose.copy(versions = Seq(persistentPurposeVersion.copy(state = Archived))))
+      val version            = createVersion(purpose.id, persistentPurposeVersion)
+      activateVersion(purpose.id, version.id, Some(persistentDocument.toAPI), stateChangeDetails)
+
+      val expected = suspendVersion(purpose.id, version.id, stateChangeDetails)
 
       val persisted = findOne[PersistentPurpose](expected.id.toString).futureValue
 

--- a/src/it/scala/it/pagopa/interop/purposemanagement/projection/cqrs/CqrsProjectionSpec.scala
+++ b/src/it/scala/it/pagopa/interop/purposemanagement/projection/cqrs/CqrsProjectionSpec.scala
@@ -66,6 +66,33 @@ class CqrsProjectionSpec extends ScalaTestWithActorTestKit(ItSpecConfiguration.c
       comparePurposes(expected, persisted)
     }
 
+    "succeed for event PurposeVersionWaitedForApproval" in {
+      val stateChangeDetails = StateChangeDetails(changedBy = ChangedBy.PRODUCER)
+      val purpose            =
+        createPurpose(persistentPurpose.copy(versions = Seq(persistentPurposeVersion.copy(state = Archived))))
+      val version            = createVersion(purpose.id, persistentPurposeVersion)
+
+      val expected = waitForApprovalVersion(purpose.id, version.id, stateChangeDetails)
+
+      val persisted = findOne[PersistentPurpose](expected.id.toString).futureValue
+
+      comparePurposes(expected, persisted)
+    }
+
+    "succeed for event PurposeVersionArchived" in {
+      val stateChangeDetails = StateChangeDetails(changedBy = ChangedBy.PRODUCER)
+      val purpose            =
+        createPurpose(persistentPurpose.copy(versions = Seq(persistentPurposeVersion.copy(state = Archived))))
+      val version            = createVersion(purpose.id, persistentPurposeVersion)
+      activateVersion(purpose.id, version.id, Some(persistentDocument.toAPI), stateChangeDetails)
+
+      val expected = archiveVersion(purpose.id, version.id, stateChangeDetails)
+
+      val persisted = findOne[PersistentPurpose](expected.id.toString).futureValue
+
+      comparePurposes(expected, persisted)
+    }
+
   }
 
 }

--- a/src/main/scala/it/pagopa/interop/purposemanagement/model/persistence/projection/PurposeCqrsProjection.scala
+++ b/src/main/scala/it/pagopa/interop/purposemanagement/model/persistence/projection/PurposeCqrsProjection.scala
@@ -15,7 +15,8 @@ import spray.json._
 import scala.concurrent.ExecutionContext
 
 object PurposeCqrsProjection {
-  def projection(offsetDbConfig: DatabaseConfig[JdbcProfile], mongoDbConfig: MongoDbConfig, projectionId: String)(implicit
+  def projection(offsetDbConfig: DatabaseConfig[JdbcProfile], mongoDbConfig: MongoDbConfig, projectionId: String)(
+    implicit
     system: ActorSystem[_],
     ec: ExecutionContext
   ): CqrsProjection[Event] =


### PR DESCRIPTION
In this PR I used a different approach compared to other CQRS integration tests:
instead of making http requests to the service, we send directly the command to the behaviour.

This way we can avoid unnecessary conversions just for testing, and most of the mocking.

This approach could be used in other services in future PRs